### PR TITLE
Prevenir NullPointerException cuando hay más de una clase de test de resource

### DIFF
--- a/src/test/java/com/demo/api/rest/resource/ApiResourceTest.java
+++ b/src/test/java/com/demo/api/rest/resource/ApiResourceTest.java
@@ -53,5 +53,6 @@ public abstract class ApiResourceTest {
     @AfterClass
     public static void tearDown() throws Exception {
         jerseyTest.tearDown();
+        jerseyTest = null;
     }
 }


### PR DESCRIPTION
Cuando existen dos o más clases de tests de resource, al hacer `jerseyTest.target("...")...` a partir de la segunda clase de test da NullPointerException ya que en JerseyTest se llama a `getTestContainer` que es null, ya que en el tearDown se esta seteando a null. Cuando se ejecuta el `setUp()` antes de ejecutar cada método jerseyTest no se inicializa (no se llama a `jerseyTest.setUp();`) por lo que el `TestContainer` es null.
